### PR TITLE
Add venue detail page, product link, profile UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.2.1",
+        "lucide-react": "^1.8.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.13.1",
@@ -2832,6 +2833,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.8.0.tgz",
+      "integrity": "sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.1",
+    "lucide-react": "^1.8.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.13.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 // Importing Pages:
 
 import Home from "./pages/Home";
+import VenueDetail from "./pages/VenueDetail";
 import About from "./pages/About";
 import Contact from "./pages/Contact";
 import Register from "./pages/Register";
@@ -21,6 +22,7 @@ function App() {
         <Navigation />
         <main className="flex-grow">
           <Routes>
+            <Route path="/venue/:id" element={<VenueDetail />} />
             <Route path="/" element={<Home />} />
             <Route path="/about" element={<About />} />
             <Route path="/contact" element={<Contact />} />

--- a/src/components/ProductCard.jsx
+++ b/src/components/ProductCard.jsx
@@ -1,5 +1,6 @@
+import { Link } from "react-router-dom";
+
 function ProductCard({ product }) {
-  console.log("Dette kortet mottok:", product);
   // Handling missing media data with optional chaining and fallback values
   const imageUrl = product.media?.[0]?.url || "https://via.placeholder.com";
   const imageAlt = product.media?.[0]?.alt || product.name;
@@ -34,10 +35,13 @@ function ProductCard({ product }) {
           </span>
         </div>
 
-        {/* Button */}
-        <button className="w-full py-2 text-sm font-semibold text-white transition-colors bg-blue-600 rounded-md hover:bg-blue-700">
-          Se detaljer
-        </button>
+        {/* See more details */}
+        <Link
+          to={`/venue/${product.id}`}
+          className="block text-center bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-full transition"
+        >
+          View Details
+        </Link>
       </div>
     </div>
   );

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -1,4 +1,89 @@
+import { useState, useEffect } from "react";
+
 function Profile() {
-  return <div>Comming soon...</div>;
+  const [profile, setProfile] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  // Getting user data from localStorage to display in the profile
+  const user = JSON.parse(localStorage.getItem("user"));
+
+  useEffect(() => {
+    // Using dummy data to simulate fetching profile info, including name, email, avatar, and bio
+    setTimeout(() => {
+      setProfile({
+        name: user?.name || "Adventurer",
+        email: user?.email || "user@mail.com",
+        avatar: "https://unsplash.com",
+        bio: "Love to explore new destinations and unique accommodations.",
+      });
+      setLoading(false);
+    }, 800);
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center min-h-[400px]">
+        <p className="text-xl font-semibold text-gray-400 animate-pulse">
+          Loading profile...
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-12">
+      {/* Profile header */}
+      <header className="mb-12 text-center">
+        <div className="relative inline-block mb-6">
+          <img
+            src={profile.avatar}
+            alt={profile.name}
+            className="w-32 h-32 rounded-full border-4 border-blue-500 shadow-xl object-cover mx-auto"
+          />
+        </div>
+        <h1 className="text-4xl font-extrabold text-white mb-2">
+          Welcome back, {profile.name}
+        </h1>
+        <p className="text-lg text-gray-300 italic">{profile.email}</p>
+      </header>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+        {/* Userdetails*/}
+        <div className="md:col-span-1 bg-gray-800/50 p-6 rounded-3xl border border-gray-700 shadow-lg">
+          <h2 className="text-xl font-bold text-white mb-4">About me</h2>
+          <p className="text-gray-400 leading-relaxed">{profile.bio}</p>
+          <button className="w-full mt-6 py-2 px-4 bg-blue-600 hover:bg-blue-700 text-white rounded-full transition-colors font-medium">
+            Edit profile
+          </button>
+        </div>
+
+        {/* Activities */}
+        <div className="md:col-span-2 space-y-6">
+          <h2 className="text-2xl font-bold text-white">My upcoming trips</h2>
+
+          {/* Booking card */}
+          <div className="bg-gray-800/30 p-4 rounded-2xl border border-gray-700 flex items-center gap-4">
+            <div className="w-20 h-20 bg-gray-700 rounded-xl overflow-hidden">
+              <div className="w-full h-full bg-blue-500/20 flex items-center justify-center text-blue-400 text-xs">
+                Image
+              </div>
+            </div>
+            <div>
+              <h3 className="text-white font-semibold">Lofoten Cabin</h3>
+              <p className="text-gray-500 text-sm">May 12 - May 15</p>
+              <span className="inline-block mt-1 px-2 py-0.5 bg-green-500/20 text-green-400 text-xs rounded-md border border-green-500/30">
+                Confirmed
+              </span>
+            </div>
+          </div>
+
+          <p className="text-center text-gray-500 italic pt-4">
+            No more orders found.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
 }
+
 export default Profile;

--- a/src/pages/VenueDetail.jsx
+++ b/src/pages/VenueDetail.jsx
@@ -1,0 +1,96 @@
+import { useState, useEffect } from "react";
+import { useParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
+import { ArrowLeft } from "lucide-react";
+
+function VenueDetail() {
+  const { id } = useParams(); // Get the venue ID from the URL parameters
+  const [venue, setVenue] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
+
+  const API_URL = import.meta.env.VITE_API_URL;
+  const API_KEY = import.meta.env.VITE_API_KEY;
+
+  useEffect(() => {
+    async function getVenueDetails() {
+      try {
+        const options = {
+          headers: {
+            "Content-Type": "application/json",
+            "X-Noroff-API-Key": API_KEY,
+          },
+        };
+        // We add the ID to the URL to fetch only one object
+        const response = await fetch(`${API_URL}/${id}`, options);
+        const json = await response.json();
+        setVenue(json.data);
+      } catch (error) {
+        console.error("Error fetching details:", error);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    getVenueDetails();
+  }, [id, API_URL, API_KEY]);
+
+  if (loading)
+    return (
+      <div className="text-white text-center mt-20">Loading details...</div>
+    );
+  if (!venue)
+    return <div className="text-white text-center mt-20">Venue not found.</div>;
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 py-12">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-12">
+        {/* Large image display */}
+        <div className="rounded-3xl overflow-hidden shadow-2xl">
+          <img
+            src={venue.media?.[0]?.url}
+            alt={venue.name}
+            className="w-full h-full object-cover"
+          />
+        </div>
+
+        {/* Information */}
+        <div className="space-y-6">
+          <h1 className="text-5xl font-extrabold text-white">{venue.name}</h1>
+          <p className="text-2xl text-blue-400 font-bold">
+            ${venue.price} / night
+          </p>
+          <div className="bg-gray-800/50 p-6 rounded-2xl border border-gray-700">
+            <h2 className="text-xl text-white font-semibold mb-2">
+              Description
+            </h2>
+            <p className="text-gray-300 leading-relaxed">{venue.description}</p>
+          </div>
+
+          <button className="w-full py-4 bg-blue-600 hover:bg-blue-700 text-white rounded-full text-xl font-bold shadow-lg transition-transform hover:scale-105">
+            Book This Venue
+          </button>
+          <div>
+            {/* Button that takes the user one step back in the history */}
+            <button
+              onClick={() => navigate(-1)}
+              className="group flex items-center gap-3 text-gray-400 hover:text-blue-400 transition-all mb-10"
+            >
+              <div className="p-2 rounded-xl bg-gray-800 border border-gray-700 group-hover:border-blue-500/50 group-hover:bg-blue-500/10 transition-all">
+                <ArrowLeft
+                  size={20}
+                  className="group-hover:-translate-x-1 transition-transform"
+                />
+              </div>
+              <span className="font-semibold tracking-wide">
+                Back to exploration
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default VenueDetail;


### PR DESCRIPTION
Introduce a new VenueDetail page and route (/venue/:id) that fetches a single venue, and uses lucide-react's ArrowLeft for navigation. Update ProductCard to remove a debug log and replace the details button with a Link to the new venue detail route. Replace the Profile placeholder with a fleshed-out profile UI that loads mock user data from localStorage and shows upcoming trips. Add lucide-react to project dependencies in package.json.